### PR TITLE
Easy installation, start, stop and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,35 @@
 sm-hub-frontend
 ================================
 
-How to run
-==========
+How to run: Everyday use
+========================
+```bash
+curl --silent https://raw.githubusercontent.com/hmrc/sm-hub-frontend/implicit-startup/sm-hub-install.sh | bash
+```
+
+This will download the latest version of sm-hub-frontend and place start and stop command in `/usr/local/bin`
+
+Once installed you can use 
+
+```bash
+sm-hub-start
+```
+
+To start sm-hub on port `1024`
+
+and 
+
+```bash
+sm-hub-stop
+```
+
+To kill the current sm-hub process
+
+To update sm-hub simply re run the install command as it will kill the current sm-hub process, purge your current version and download the latest.
+
+
+How to run: Local development
+=============================
 
 ```sbtshell
 sbt -DsmPath=/Users/foo/bar/config-location -Dworkspace=/Users/foo/bar/location-of-services -DgithubOrg=your-github-org-name run

--- a/app/assets/stylesheets/global-assets.scss
+++ b/app/assets/stylesheets/global-assets.scss
@@ -44,3 +44,24 @@
   -webkit-hyphens: auto;
   hyphens: auto;
 }
+
+.update-alert {
+  @extend .alert;
+  background-color: #FFFFFF;
+  font-size: 17px;
+  height: auto;
+  border-bottom: 6px solid #3a7aaa;
+
+  a {
+    text-decoration: underline;
+  }
+
+  .update-tag {
+    border: solid;
+    border-radius: 10px;
+    padding: 5px 10px 5px 10px;
+    color: #ffffff;
+    background-color: #3a7aaa;
+    border: #3a7aaa;
+  }
+}

--- a/app/common/FrontendModule.scala
+++ b/app/common/FrontendModule.scala
@@ -17,9 +17,9 @@
 package common
 
 import com.google.inject.AbstractModule
-import connectors.{DefaultHttpConnector, DefaultJsonConnector, HttpConnector, JsonConnector}
+import connectors._
 import controllers.{DefaultMainController, MainController}
-import filters.{DefaultRequestLoggingFilter, RequestLoggingFilter}
+import filters.{DefaultRequestLoggingFilter, DefaultUpdateFilter, RequestLoggingFilter, UpdateFilter}
 import services.{DefaultSMService, SMService}
 
 class FrontendModule extends AbstractModule {
@@ -33,12 +33,14 @@ class FrontendModule extends AbstractModule {
   def bindCommon(): Unit = {
     bind(classOf[Http]).to(classOf[DefaultHttp]).asEagerSingleton()
     bind(classOf[RequestLoggingFilter]).to(classOf[DefaultRequestLoggingFilter]).asEagerSingleton()
+    bind(classOf[UpdateFilter]).to(classOf[DefaultUpdateFilter]).asEagerSingleton()
     bind(classOf[ErrorHandler]).to(classOf[DefaultErrorHandler]).asEagerSingleton()
   }
 
   def bindConnectors(): Unit = {
     bind(classOf[JsonConnector]).to(classOf[DefaultJsonConnector]).asEagerSingleton()
     bind(classOf[HttpConnector]).to(classOf[DefaultHttpConnector]).asEagerSingleton()
+    bind(classOf[UpdateConnector]).to(classOf[DefaultUpdateConnector]).asEagerSingleton()
   }
 
   def bindServices(): Unit = {

--- a/app/connectors/UpdateConnector.scala
+++ b/app/connectors/UpdateConnector.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import common.Http
+import javax.inject.Inject
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class DefaultUpdateConnector @Inject()(val http: Http) extends UpdateConnector {
+  override val currentVersion: Option[String] = Option(System.getProperty("currentVersion"))
+}
+
+trait UpdateConnector {
+
+  val http: Http
+
+  val currentVersion: Option[String]
+
+  def isUpdateAvailable: Future[Boolean] = {
+    http.get("https://api.github.com/repos/hmrc/sm-hub-frontend/releases/latest") map { resp =>
+      val latestVersion  = resp.json.\("name").asOpt[String]
+      (latestVersion, currentVersion) match {
+        case (Some(lv), Some(cv)) => !(lv == cv)
+        case (_, _)               => false
+      }
+    }
+  }
+}

--- a/app/filters/EnabledFilters.scala
+++ b/app/filters/EnabledFilters.scala
@@ -20,5 +20,5 @@ import javax.inject.Inject
 
 import play.api.http.DefaultHttpFilters
 
-class EnabledFilters @Inject()(requestLoggingFilter: RequestLoggingFilter)
-  extends DefaultHttpFilters(requestLoggingFilter)
+class EnabledFilters @Inject()(requestLoggingFilter: RequestLoggingFilter, updateFilter: UpdateFilter)
+  extends DefaultHttpFilters(requestLoggingFilter, updateFilter)

--- a/app/filters/UpdateFilter.scala
+++ b/app/filters/UpdateFilter.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import akka.stream.Materializer
+import common.Logging
+import connectors.UpdateConnector
+import javax.inject.Inject
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+class DefaultUpdateFilter @Inject()(implicit val mat: Materializer,
+                                    val updateConnector: UpdateConnector) extends UpdateFilter
+
+trait UpdateFilter extends Filter with Logging {
+
+  val updateConnector: UpdateConnector
+
+  override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+    if(rh.uri.contains("assets")) {
+      f(rh)
+    } else {
+      logger.info("fetching latest version from github")
+      for {
+        update <- updateConnector.isUpdateAvailable
+        result <- f(rh.copy(headers = rh.headers.add("update" -> update.toString)))
+      } yield result
+    }
+  }
+}

--- a/app/services/SMService.scala
+++ b/app/services/SMService.scala
@@ -55,13 +55,11 @@ trait SMService extends Logging {
     }
   }
 
- private def pingMultipleServices(services:Seq[(String,String,Int)]):Future[Seq[RunningResponse]] = {
-  Future.sequence(services.map{ service => {
-    val (name, url, port) = service
-    httpConnector.pingService(name, url, port)
-    }
-  })
- }
+  private def pingMultipleServices(services: Seq[(String, String, Int)]): Future[Seq[RunningResponse]] = {
+    Future.sequence(services map {
+      case (name, url, port) => httpConnector.pingService(name, url, port)
+    })
+  }
 
   def getValidPortNumbers(searchedRange: Option[(Int, Int)]): Seq[Int] = {
     searchedRange match {

--- a/app/views/templates/main_template.scala.html
+++ b/app/views/templates/main_template.scala.html
@@ -9,6 +9,15 @@
     <body>
         @NavBar()
 
+        @if(request.headers.get("update").getOrElse("false").toBoolean) {
+        <div class="alert update-alert alert-dismissible" role="alert" style="margin-top: -20px;">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <div class="text-center">
+                <span class="update-tag"><strong>UPDATE</strong></span> An update is available; to update re-run the installation script found in the <a href="https://github.com/hmrc/sm-hub-frontend">Read Me</a>
+            </div>
+        </div>
+        }
+
         <div class="top-block-single">
             <div class="container">
                 <div class="row">

--- a/public/stylesheets/bootstrap.css
+++ b/public/stylesheets/bootstrap.css
@@ -4168,7 +4168,6 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar {
   position: relative;
   min-height: 50px;
-  margin-bottom: 20px;
   border: 1px solid transparent;
 }
 @media (min-width: 768px) {

--- a/sm-hub-install.sh
+++ b/sm-hub-install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+echo "Killing existing sm-hub processes and cleaning current sm-hub"
+$pid
+pid=$(lsof -i -a | grep 1024 | awk -F" " '{print $2}')
+kill -9 $pid
+rm ~/Applications/sm-hub-frontend/sm-hub-frontend-VERSION/sm-hub-frontend-VERSION/RUNNING_PID
+
+rm -rf ~/Applications/sm-hub-frontend
+
+sudo rm /usr/local/bin/sm-hub-start
+sudo rm /usr/local/bin/sm-hub-stop
+
+echo "Creating new home for sm-hub"
+mkdir -p ~/Applications/sm-hub-frontend/
+
+$latest_version
+
+echo "Getting latest version of sm-hub"
+latest_version="$(curl --silent "https://api.github.com/repos/hmrc/sm-hub-frontend/releases/latest" | grep '"name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+
+echo "Downloading version $latest_version of sm-hub-frontend to $HOME/Applications/sm-hub-frontend"
+curl -L https://hmrc.bintray.com/releases/uk/gov/hmrc/sm-hub-frontend_2.11/$latest_version/sm-hub-frontend_2.11-$latest_version.tgz --output ~/Applications/sm-hub-frontend/sm-hub-frontend-$latest_version.tgz
+
+mkdir -p ~/Applications/sm-hub-frontend/sm-hub-frontend-$latest_version
+
+echo "Unpacking sm-hub from tgz"
+tar -xzf ~/Applications/sm-hub-frontend/sm-hub-frontend-$latest_version.tgz --directory ~/Applications/sm-hub-frontend/sm-hub-frontend-$latest_version
+
+rm ~/Applications/sm-hub-frontend/sm-hub-frontend-$latest_version.tgz
+
+echo "Downloaded version $latest_version of sm-hub-frontend to $HOME/Applications/sm-hub-frontend"
+
+echo "Fetching sm-hub start and stop scripts"
+sudo curl --silent -L https://raw.githubusercontent.com/hmrc/sm-hub-frontend/implicit-startup/sm-hub-start.sh --output /usr/local/bin/sm-hub-start
+sudo curl --silent -L https://raw.githubusercontent.com/hmrc/sm-hub-frontend/implicit-startup/sm-hub-stop.sh --output /usr/local/bin/sm-hub-stop
+
+sudo chmod +x /usr/local/bin/sm-hub-*
+
+sudo sed -i -e "s/VERSION/${latest_version}/g" /usr/local/bin/sm-hub-start
+sudo sed -i -e "s/VERSION/${latest_version}/g" /usr/local/bin/sm-hub-stop
+
+sudo rm /usr/local/bin/sm-hub-*-e
+
+sudo chown `whoami`:admin /usr/local/bin/sm-hub-start
+sudo chown `whoami`:admin /usr/local/bin/sm-hub-stop
+sudo chown -R `whoami`:staff ~/Applications/sm-hub-frontend
+
+echo "Installation complete"
+echo "To update sm-hub re run this command"
+echo "To start sm-hub run 'sm-hub-start' from any terminal"
+echo "To stop sm-hub run 'sm-hub-stop' from any terminal"
+echo "Logs can be found in $HOME/Applications/sm-hub-frontend/logs"
+
+

--- a/sm-hub-start.sh
+++ b/sm-hub-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "Starting sm-hub on port 1024"
+~/Applications/sm-hub-frontend/sm-hub-frontend-VERSION/sm-hub-frontend-VERSION/bin/sm-hub-frontend -DsmPath=$WORKSPACE/service-manager-config -DgithubOrg=hmrc -Dworkspace=$WORKSPACE -Dhttp.port=1024 > ~/Applications/sm-hub-frontend/logs 2>&1 &
+
+echo "sm-hub can be found at http://localhost:1024/sm-hub/running-services"

--- a/sm-hub-start.sh
+++ b/sm-hub-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 echo "Starting sm-hub on port 1024"
-~/Applications/sm-hub-frontend/sm-hub-frontend-VERSION/sm-hub-frontend-VERSION/bin/sm-hub-frontend -DsmPath=$WORKSPACE/service-manager-config -DgithubOrg=hmrc -Dworkspace=$WORKSPACE -Dhttp.port=1024 > ~/Applications/sm-hub-frontend/logs 2>&1 &
+~/Applications/sm-hub-frontend/sm-hub-frontend-VERSION/sm-hub-frontend-VERSION/bin/sm-hub-frontend -DsmPath=$WORKSPACE/service-manager-config -DgithubOrg=hmrc -Dworkspace=$WORKSPACE -Dhttp.port=1024 -DcurrentVersion=VERSION > ~/Applications/sm-hub-frontend/logs 2>&1 &
 
 echo "sm-hub can be found at http://localhost:1024/sm-hub/running-services"

--- a/sm-hub-stop.sh
+++ b/sm-hub-stop.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "Killing sm-hub process"
+$pid
+pid=$(lsof -i -a | grep 1024 | awk -F" " '{print $2}')
+kill -9 $pid
+rm ~/Applications/sm-hub-frontend/sm-hub-frontend-VERSION/sm-hub-frontend-VERSION/RUNNING_PID

--- a/sm-hub-stop.sh
+++ b/sm-hub-stop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "Killing sm-hub process"
 $pid
-pid=$(lsof -i -a | grep 1024 | awk -F" " '{print $2}')
+pid=$(lsof -i -a | grep -E 'java.*1024' | awk -F" " '{print $2}')
 kill -9 $pid
 rm ~/Applications/sm-hub-frontend/sm-hub-frontend-VERSION/sm-hub-frontend-VERSION/RUNNING_PID

--- a/test/connectors/UpdateConnectorSpec.scala
+++ b/test/connectors/UpdateConnectorSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import common.Http
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.{reset, when}
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSResponse
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UpdateConnectorSpec extends PlaySpec with MockitoSugar with FutureAwaits with DefaultAwaitTimeout with BeforeAndAfterEach {
+
+  val mockHttpClient = mock[Http]
+
+  def testConnector(currentVer: Option[String]): UpdateConnector = new UpdateConnector {
+    override val http           = mockHttpClient
+    override val currentVersion = currentVer
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockHttpClient)
+  }
+
+  def fakeResponse(statusInt: Int, bodyIn: JsValue): WSResponse = new WSResponse {
+    override def cookie(name: String) = ???
+    override def underlying[T]        = ???
+    override def body                 = ???
+    override def bodyAsBytes          = ???
+    override def cookies              = ???
+    override def allHeaders           = ???
+    override def xml                  = ???
+    override def statusText           = ???
+    override def json                 = bodyIn
+    override def header(key: String)  = ???
+    override def status               = statusInt
+  }
+
+  val OK = 200
+
+  "isUpdateAvailable" should {
+    "return true" when {
+      "the current version and latest version don't match" in {
+        when(mockHttpClient.get(ArgumentMatchers.any()))
+          .thenReturn(Future(fakeResponse(OK, Json.parse("""{ "name" : "0.6.0" }"""))))
+
+        val result = await(testConnector(Some("0.3.0")).isUpdateAvailable)
+        assert(result)
+      }
+    }
+
+    "return false" when {
+      "the current version and latest version do match" in {
+        when(mockHttpClient.get(ArgumentMatchers.any()))
+          .thenReturn(Future(fakeResponse(OK, Json.parse("""{ "name" : "0.6.0" }"""))))
+
+        val result = await(testConnector(Some("0.6.0")).isUpdateAvailable)
+        assert(!result)
+      }
+
+      "the current version couldn't be pulled from the config" in {
+        when(mockHttpClient.get(ArgumentMatchers.any()))
+          .thenReturn(Future(fakeResponse(OK, Json.parse("""{ "name" : "0.6.0" }"""))))
+
+        val result = await(testConnector(None).isUpdateAvailable)
+        assert(!result)
+      }
+
+      "the latest version couldn't be pulled from git" in {
+        when(mockHttpClient.get(ArgumentMatchers.any()))
+          .thenReturn(Future(fakeResponse(OK, Json.parse("""{ "abc" : "xyz" }"""))))
+
+        val result = await(testConnector(Some("0.3.0")).isUpdateAvailable)
+        assert(!result)
+      }
+
+      "neither the current or latest version could be pulled" in {
+        when(mockHttpClient.get(ArgumentMatchers.any()))
+          .thenReturn(Future(fakeResponse(OK, Json.parse("""{ "abc" : "xyz" }"""))))
+
+        val result = await(testConnector(None).isUpdateAvailable)
+        assert(!result)
+      }
+    }
+  }
+}


### PR DESCRIPTION
As part of this PR, three scripts have been created.

- Installation
- Start
- Stop

### Installation
The installation script first kills any sm-hub processes and then purges the sm-hub installation directories and bin scripts. After pulling the latest version tag from GitHub it then downloads the corresponding artefact from bintray and unpacks it into users`~/Applications` folder. It then fetches the start and stop scripts and places them into `/usr/local/bin` ensuring they are executable and have the correct owner. Having them in `/usr/local/bin` makes these scripts accessible anywhere as the bin should be on the path.

### Start 
Start is ran with `sm-hub-start`. It accesses the directory sm-hub was installed in and runs the script unpacked from the tgz with the needed arguments in prod mode. 

### Stop
Stop is ran with `sm-hub-stop`. Using `lsof` it searches for a PiD matching port `1024` and kills it

### Update
Not an official script, but update functionality is provided by running the installation script again, as it first kills and purges sm-hub before downloading the latest version. 

# PLEASE NOTE
For the purpose of development and code review, the installation script described above and as highlighted In the README current current downloads scripts from THIS BRANCH. Once reviewed and approved this PR will have to be updated to point to the master branch. 