### PR TITLE
Added ability to view service logs

### DIFF
--- a/app/assets/stylesheets/global-assets-dark-mode.scss
+++ b/app/assets/stylesheets/global-assets-dark-mode.scss
@@ -230,3 +230,7 @@ table {
   hyphens: auto;
 }
 
+.log {
+  background: #222;
+  color: invert(#222);
+}

--- a/app/controllers/MainController.scala
+++ b/app/controllers/MainController.scala
@@ -17,9 +17,9 @@
 package controllers
 
 import java.io.File
+import javax.inject.Inject
 
 import forms.{AllProfilesForm, AllServiceForm, AvailablePortsForm, RunningServicesForm, _}
-import javax.inject.Inject
 import models.ConfigSetup
 import play.api.Configuration
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -161,5 +161,9 @@ trait MainController extends Controller with I18nSupport {
       errors => BadRequest(GenerateConfigView(errors)),
       valid  => Ok(GeneratedConfig(Json.prettyPrint(Json.toJson(valid)(ConfigSetup.writes(githubOrg)))))
     )
+  }
+
+  def viewServiceLogs(service : String) : Action[AnyContent] = Action { implicit request =>
+    Ok(ServiceLogsView(smService.retrieveServiceLogs(service), service))
   }
 }

--- a/app/services/SMService.scala
+++ b/app/services/SMService.scala
@@ -27,6 +27,7 @@ import play.api.libs.json.{JsObject, JsValue}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Awaitable, Future}
+import scala.sys.process.Process
 
 class DefaultSMService @Inject()(val jsonConnector: JsonConnector,
                                  val httpConnector: HttpConnector,
@@ -161,5 +162,9 @@ trait SMService extends Logging {
         case (service, js) if js.\("sources").\("repo").as[String].contains("tools") =>
           service -> js.\("sources").\("repo").as[String]
       }
+  }
+
+  def retrieveServiceLogs(service : String): String = {
+    Process(s"sm -l $service").!!.takeRight(100000).trim
   }
 }

--- a/app/views/pages/ServiceLogsView.scala.html
+++ b/app/views/pages/ServiceLogsView.scala.html
@@ -1,0 +1,21 @@
+@import views.html.templates.main_template
+
+@import play.api.libs.json.JsObject
+
+@(log : String, service : String)(implicit request: RequestHeader, messages: Messages)
+
+@main_template(title = messages("app.tab-title")) {
+    <div class="col-md-9">
+        <h2>@messages("pages.log.heading", service)</h2>
+        <hr>
+        <div class="row">
+            <pre id="log" class="log" style="overflow:scroll; height:800px; font-size: 11px;">@log</pre>
+        </div>
+    </div>
+
+    <script>
+            $(document).ready(function () {
+                $('#log').scrollTop($('#log')[0].scrollHeight);
+            });
+    </script>
+}

--- a/app/views/templates/RunningServiceDisplay.scala.html
+++ b/app/views/templates/RunningServiceDisplay.scala.html
@@ -31,5 +31,8 @@
             <a id="@{runningStatus.name}-restart-link" href="@routes.MainController.home(profile, "restart "+runningStatus.name+" -f")">
                 <button title="@messages("pages.running-apps.restart-service")" class="btn btn-primary"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span></button>
             </a>
+            <a id="@{runningStatus.name}-log-link" href="@routes.MainController.viewServiceLogs({runningStatus.name})">
+                <button title="@messages("pages.running-apps.logs-service")" class="btn btn-primary"><span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span></button>
+            </a>
         </div>
     </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -28,5 +28,7 @@ GET     /test-routes-for-service    controllers.MainController.serviceTestRoutes
 GET     /assets-versions            controllers.MainController.availableAssetsVersions()
 GET     /find-ghe-references        controllers.MainController.findGHEReferences()
 
+GET     /service-logs               controllers.MainController.viewServiceLogs(service ?= "")
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/conf/messages
+++ b/conf/messages
@@ -139,6 +139,7 @@ pages.generated-config.heading              = Your new config
 pages.generated-config.info                 = All of this json is completely editable, if anything looks wrong, edit it before copying
 pages.generated-config.copy                 = Copy to clipboard
 
+pages.log.heading                           = Recent logs for {0}
 
 
 

--- a/test/controllers/MainControllerSpec.scala
+++ b/test/controllers/MainControllerSpec.scala
@@ -321,4 +321,15 @@ class MainControllerSpec extends PlaySpec with MockitoSugar with BeforeAndAfterE
       status(result) mustBe BAD_REQUEST
     }
   }
+
+  "viewServiceLogs" should {
+    "return an Ok on a valid service" in {
+      when(mockSMService.retrieveServiceLogs("service"))
+        .thenReturn("TEST_LOG")
+
+      val result = testController.viewServiceLogs("service")(request)
+      status(result) mustBe OK
+      contentAsString(result) must include("TEST_LOG")
+    }
+  }
 }


### PR DESCRIPTION
# Added the ability to view service logs

Adds the ability to view service logs for a given service. This appears as a new button on the services view page for each service.

![image](https://user-images.githubusercontent.com/31282623/43311434-5aef580a-9182-11e8-9430-de68289b3bf1.png)
![image](https://user-images.githubusercontent.com/31282623/43311438-6128aae6-9182-11e8-9456-75efeb458f17.png)
