### PR TITLE
Added ability to find x amount of consecutive ports within a given range

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ sbt clean coverage test coverageReport
 Features
 ========
 - See currently running services based your teams sm profile
+- Start, stop and restart one service or a profiles worth of services
+- View service logs
 - Search through all available profiles
 - Search through all available services
 - See which ports are available to use
+- Find a set of consecutive ports between a given range
 - See conflicting port usages
 - Catalogue of test routes for services
 - See currently available versions of assets frontend
-- Generate config
+- Generate config (For demo purposes at the moment, i.e not complete)
 
 License
 =======

--- a/app/forms/AvailablePortsForm.scala
+++ b/app/forms/AvailablePortsForm.scala
@@ -22,10 +22,11 @@ import play.api.data.Forms._
 import play.api.i18n.Messages
 
 object AvailablePortsForm {
-  def form(implicit messages: Messages): Form[(Int, Int)] = Form(
+  def form(implicit messages: Messages): Form[(Int, Int, Option[Int])] = Form(
     tuple(
       "startPort" -> Validation.portMapping,
-      "endPort"   -> Validation.portMapping
+      "endPort"   -> Validation.portMapping,
+      "step"      -> optional(number)
     )
   )
 }

--- a/app/views/pages/ConsecutivePortsPage.scala.html
+++ b/app/views/pages/ConsecutivePortsPage.scala.html
@@ -1,0 +1,13 @@
+@import views.html.templates.{RunningServiceDisplay, main_template, ErrorPanel}
+@import common.{RunningResponse, GreenResponse}
+
+@()(implicit request: RequestHeader, messages: Messages)
+
+@main_template(title = messages("app.tab-title")) {
+
+    <div class="col-md-9">
+        <h2>@messages("pages.running-apps.heading")</h2>
+        <hr>
+    </div>
+
+}

--- a/app/views/pages/PortsView.scala.html
+++ b/app/views/pages/PortsView.scala.html
@@ -1,6 +1,6 @@
 @import views.html.templates.{main_template, ErrorPanel}
 
-@(ports: Seq[Int], form: Form[(Int, Int)])(implicit request: RequestHeader, messages: Messages)
+@(ports: Seq[Int], consecutivePorts: List[List[Int]], form: Form[(Int, Int, Option[Int])])(implicit request: RequestHeader, messages: Messages)
 
 @main_template(title = messages("app.tab-title")) {
     <div class="col-md-9">
@@ -20,21 +20,36 @@
                             <input id="endPort" name="endPort" type="text" class="form-control" aria-describedby="sizing-addon1" value="@form("endPort").value">
                         </div>
                     </div>
-                    <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-plane" aria-hidden="true"></span> @messages("app.search")</button>
+
+                    <br>
+                    <br>
+
+                    <div class="form-group">
+                        <div class="input-group @if(form.hasErrors) { has-error }">
+                            <span class="input-group-addon" id="sizing-addon1">@messages("pages.available-ports.form.amount")</span>
+                            <input id="step" name="step" type="text" class="form-control" aria-describedby="sizing-addon1" value="@form("step").value">
+                        </div>
+
+                        <div class="input-group">
+                            <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-plane" aria-hidden="true"></span> @messages("app.search")</button>
+                        </div>
+                    </div>
                 </form>
             </div>
 
-            <div id="result-count" class="col-md-3">
-                <strong class="h1">@{ports.size}</strong> @messages("pages.available-ports.count")
-            </div>
+            @if(ports.nonEmpty) {
+                <div id="result-count" class="col-md-3">
+                    <strong class="h1">@{ports.size}</strong> @messages("pages.available-ports.count")
+                </div>
+            }
         </div>
         @if(form.hasErrors) {
             <hr>
             @ErrorPanel(form)
         }
         <hr>
-        <div class="row">
         @if(ports.nonEmpty) {
+        <div class="row">
             @for(port <- ports) {
                 <div class="col-md-2">
                     <div class="alert alert-info text-center lead" role="alert">
@@ -42,9 +57,29 @@
                     </div>
                 </div>
             }
-        } else {
+        </div>
+        }
+
+        @if(consecutivePorts.nonEmpty) {
+            <div class="col-md-12">
+            @for((portList, x) <- consecutivePorts.zipWithIndex) {
+                    <div class="row">
+                        <h4>Option @{x + 1}</h4>
+                        <hr>
+                        @for(port <- portList) {
+                            <div class="col-md-2">
+                                <div class="alert alert-info text-center lead" role="alert">
+                                    <p class="text-center"><strong>@port</strong></p>
+                                </div>
+                            </div>
+                        }
+                    </div>
+            }
+            </div>
+        }
+
+        @if(ports.isEmpty && consecutivePorts.isEmpty) {
             <p class="text-center lead">@messages("pages.available-ports.no-ports")</p>
         }
-        </div>
     </div>
 }

--- a/app/views/pages/ServiceTestRoutesView.scala.html
+++ b/app/views/pages/ServiceTestRoutesView.scala.html
@@ -14,7 +14,7 @@
         @if(servicesWithTestRoutes.nonEmpty) {
             @for(service <- servicesWithTestRoutes) {
                 <div class="col-md-6">
-                    <div class="alert alert-info text-center lead">
+                    <div class="alert alert-info text-center lead current-textbox">
                         <a href="@routes.MainController.serviceTestRoutesExpanded(service)">
                             <strong>@service</strong>
                         </a>

--- a/app/views/pages/ServicesInProfileView.scala.html
+++ b/app/views/pages/ServicesInProfileView.scala.html
@@ -10,7 +10,7 @@
         @if(services.nonEmpty) {
             @for(service <- services) {
                 <div class="col-md-6">
-                    <div class="alert alert-info text-center lead">
+                    <div class="alert alert-info text-center lead current-textbox">
                         <a href="@routes.MainController.detailsForService(service)">
                             <strong>@service</strong>
                         </a>

--- a/app/views/templates/RunningServiceDisplay.scala.html
+++ b/app/views/templates/RunningServiceDisplay.scala.html
@@ -31,7 +31,7 @@
             <a id="@{runningStatus.name}-restart-link" href="@routes.MainController.home(profile, "restart "+runningStatus.name+" -f")">
                 <button title="@messages("pages.running-apps.restart-service")" class="btn btn-primary"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span></button>
             </a>
-            <a id="@{runningStatus.name}-log-link" href="@routes.MainController.viewServiceLogs({runningStatus.name})">
+            <a id="@{runningStatus.name}-log-link" href="@routes.MainController.viewServiceLogs(runningStatus.name)">
                 <button title="@messages("pages.running-apps.logs-service")" class="btn btn-primary"><span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span></button>
             </a>
         </div>

--- a/conf/messages
+++ b/conf/messages
@@ -81,7 +81,8 @@ pages.available-ports.heading               = Available ports
 pages.available-ports.count                 = ports in range
 pages.available-ports.form.start            = Start port
 pages.available-ports.form.end              = End port
-pages.available-ports.no-ports              = Please search for a port range
+pages.available-ports.form.amount           = Amount
+pages.available-ports.no-ports              = Search for ports between one number and another to get all ports in that range. Enter a number into the amount field to get that amount of consecutive ports in that range.
 
 pages.potential-conflicts.heading           = Potential port conflicts
 pages.potential-conflicts.count             = potential conflicts

--- a/test/controllers/MainControllerSpec.scala
+++ b/test/controllers/MainControllerSpec.scala
@@ -50,7 +50,7 @@ class MainControllerSpec extends PlaySpec with MockitoSugar with BeforeAndAfterE
     override val smService     = mockSMService
   }
 
-  val lang = Lang("en")
+  val lang     = Lang("en")
   val messages = Messages(lang, mockMessagesApi)
 
   val MOCKED_MESSAGE = "mocked message"
@@ -139,6 +139,16 @@ class MainControllerSpec extends PlaySpec with MockitoSugar with BeforeAndAfterE
 
         when(mockSMService.getValidPortNumbers(ArgumentMatchers.any()))
           .thenReturn(Seq(1024, 1025, 1026))
+
+        val result = testController.submitAvailablePorts()(request)
+        status(result) mustBe OK
+      }
+
+      "the range and amount have both been provided" in {
+        val request = FakeRequest().withFormUrlEncodedBody("startPort" -> "1024", "endPort" -> "1030", "step" -> "2")
+
+        when(mockSMService.getConsecutivePorts(ArgumentMatchers.any(), ArgumentMatchers.any()))
+          .thenReturn(List(List(1024, 1025), List(1026, 1027)))
 
         val result = testController.submitAvailablePorts()(request)
         status(result) mustBe OK

--- a/test/services/SMServiceSpec.scala
+++ b/test/services/SMServiceSpec.scala
@@ -447,4 +447,99 @@ class SMServiceSpec extends PlaySpec with MockitoSugar with BeforeAndAfterEach {
       result mustBe List()
     }
   }
+
+  "getConsecutivePorts" should {
+
+    "return the same output as getValidPorts" when {
+      "the step is set to 1 and consecutive ports is flattened" in {
+        val testRange = (1024 to 1030).toList
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val consecutivePorts = testService.getConsecutivePorts(testRange, step = 1).flatten
+        val validPorts       = testService.getValidPortNumbers(Some(1024, 1030))
+
+        consecutivePorts mustBe validPorts
+      }
+    }
+
+    "return an empty list" when {
+      "no sets of consecutive numbers can be found" in {
+        val testSearchRange = List(5,1,8,9,6,5,3,4,6,7,1,8,3)
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 3)
+        assert(result.isEmpty)
+      }
+    }
+
+    "return a list with one list" when {
+      "there are two groups of consecutive numbers grouped by 4" in {
+        val testSearchRange = (1024 to 1032).toList
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 4)
+        result mustBe List(List(1027, 1028, 1029, 1030))
+      }
+
+      "the input list is jumbled" in {
+        val testSearchRange = List(1,6,8,4,3,78,1,2,3,7,89,3,3,345,567,1)
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 3)
+        result mustBe List(List(1,2,3))
+      }
+    }
+
+    "return a list of 2 lists" when {
+      "there are two groups of consecutive numbers grouped by 3" in {
+        val testSearchRange = (1024 to 1032).toList
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 3)
+        result mustBe List(List(1027, 1028, 1029), List(1030, 1031, 1032))
+      }
+
+      "the input list is jumbled" in {
+        val testSearchRange = List(5,6,7,4,3,78,1,2,3,7,89,3,3,345,567,1)
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 3)
+        result mustBe List(List(5,6,7), List(1,2,3))
+      }
+    }
+
+    "return a list of 3 lists" when {
+      "there are 3 groups of consecutive numbers grouped by 2" in {
+        val testSearchRange = (1024 to 1032).toList
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 2)
+        result mustBe List(List(1027, 1028), List(1029, 1030), List(1031, 1032))
+      }
+
+      "the input list is jumbled" in {
+        val testSearchRange = List(5,6,7,4,3,78,1,2,3,7,89,3,344,345,346,1)
+
+        when(mockJsonConnector.loadServicesJson)
+          .thenReturn(servicesJson)
+
+        val result = testService.getConsecutivePorts(testSearchRange, step = 3)
+        result mustBe List(List(5,6,7), List(1,2,3), List(344,345,346))
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Overview
The available ports page has been refactored to support searching for all available ports within a given range as well finding all X amount of consecutive ports within a given range.

### Available ports page
Before => 
![screen shot 2018-08-02 at 16 46 12](https://user-images.githubusercontent.com/8091191/43645579-447eb8ec-972a-11e8-91ff-67a431303a43.png)

After =>
![screen shot 2018-08-03 at 14 34 56](https://user-images.githubusercontent.com/8091191/43645638-7177f872-972a-11e8-872e-72b51f193fdb.png)

The amount form field has been added to support finding consecutive ports. This field is optional and if it not provided the page will behave the same as before (as described in the before screenshot), providing the amount field will then activate the consecutive port search and provide the user with options as to what their set of ports could be. 

PR also includes some general code cleanup and an update README. This PR relates to issue #6 