### PR TITLE
fixed bug that prevent people from seeing the service details page

### DIFF
--- a/app/views/templates/RunningServiceDisplay.scala.html
+++ b/app/views/templates/RunningServiceDisplay.scala.html
@@ -18,7 +18,7 @@
 
     <div class="col-md-4">
         <div id="@{runningStatus.name}-running-response" class="alert @evaluateResponse() text-center" role="alert">
-            <a id="@{runningStatus.name}-details-link" href="@routes.MainController.detailsForService()">
+            <a id="@{runningStatus.name}-details-link" href="@routes.MainController.detailsForService(runningStatus.name)">
                 @{runningStatus.name} <br> @{runningStatus.port}
             </a>
             <br><br>


### PR DESCRIPTION
Bug: When clicking on the service name in running services, the service name was not carried forward to the url resulting in a technical difficulties page.